### PR TITLE
fix(LuaMgr): preserve lastChecked

### DIFF
--- a/src/core/github/repository.hpp
+++ b/src/core/github/repository.hpp
@@ -1,4 +1,4 @@
-// YLP Project - GPL-3.0
+﻿// YLP Project - GPL-3.0
 // See LICENSE file or <https://www.gnu.org/licenses/> for details.
 
 
@@ -27,6 +27,9 @@ namespace YLP
 
 		bool is_outdated() const
 		{
+			if (!isInstalled)
+				return false;
+
 			if (lastChecked.time_since_epoch().count() == 0)
 				return false;
 

--- a/src/core/memory/procmon.cpp
+++ b/src/core/memory/procmon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 SAMURAI (xesdoog) & Contributors
+﻿// Copyright (C) 2025 SAMURAI (xesdoog) & Contributors
 // This file is part of YLP.
 //
 // YLP is free software: you can redistribute it and/or modify
@@ -102,6 +102,9 @@ namespace YLP
 		return Utils::WaitUntil([&] {
 			HWND hwnd = PsUtils::GetHwndFromPid(m_Scanner->GetProcessID());
 			if (!IsWindow(hwnd))
+				return false;
+
+			if (!m_Scanner->IsModuleLoaded("socialclub.dll"))
 				return false;
 
 			std::this_thread::sleep_for(2s);
@@ -298,7 +301,7 @@ namespace YLP
 
 							auto& pointers = (m_MonitorMode == MonitorLegacy) ? g_Pointers.Legacy : g_Pointers.Enhanced;
 							pointers.Reset();
-							std::this_thread::sleep_for(5s);
+							std::this_thread::sleep_for(20s);
 						}
 					}
 				}


### PR DESCRIPTION
### 🔧 Fix

- Attempt to fix `FetchRepositories` from overwriting cached `lastChecked` keys
- Attempt to prevent scanning memory too early by waiting for the social club module to load.